### PR TITLE
Mangle rust buffer functions

### DIFF
--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -202,11 +202,7 @@ impl Default for RustBuffer {
 /// to the foreign-language code as a `RustBuffer` struct. Callers must eventually
 /// free the resulting buffer, either by explicitly calling [`uniffi_rustbuffer_free`] defined
 /// below, or by passing ownership of the buffer back into Rust code.
-#[no_mangle]
-pub extern "C" fn uniffi_rustbuffer_alloc(
-    size: i32,
-    call_status: &mut RustCallStatus,
-) -> RustBuffer {
+pub fn uniffi_rustbuffer_alloc(size: i32, call_status: &mut RustCallStatus) -> RustBuffer {
     call_with_output(call_status, || {
         RustBuffer::new_with_size(size.max(0) as usize)
     })
@@ -220,8 +216,7 @@ pub extern "C" fn uniffi_rustbuffer_alloc(
 /// # Safety
 /// This function will dereference a provided pointer in order to copy bytes from it, so
 /// make sure the `ForeignBytes` struct contains a valid pointer and length.
-#[no_mangle]
-pub unsafe extern "C" fn uniffi_rustbuffer_from_bytes(
+pub fn uniffi_rustbuffer_from_bytes(
     bytes: ForeignBytes,
     call_status: &mut RustCallStatus,
 ) -> RustBuffer {
@@ -237,8 +232,7 @@ pub unsafe extern "C" fn uniffi_rustbuffer_from_bytes(
 /// The argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
-#[no_mangle]
-pub unsafe extern "C" fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus) {
+pub unsafe fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus) {
     call_with_output(call_status, || RustBuffer::destroy(buf))
 }
 
@@ -257,8 +251,7 @@ pub unsafe extern "C" fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &m
 /// The first argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
-#[no_mangle]
-pub unsafe extern "C" fn uniffi_rustbuffer_reserve(
+pub fn uniffi_rustbuffer_reserve(
     buf: RustBuffer,
     additional: i32,
     call_status: &mut RustCallStatus,


### PR DESCRIPTION
Not mangling these functions cause duplicate symbol errors when attempting to link 2 static libraries containing different uniffi versions. The error also appears when linking 2 static libraries containing the same uniffi version, but when the libraries are compiled on different architecture machies, e.g. MacOS Intel and MacOS Arm.

These Rust buffer functions are already exposed with a namespace prefix in RustBuffer.rs, and foreign language bindings use these prefixed functions, so no additional changes are required.