### PR TITLE
Append custom types example to include C# and Go configuration

### DIFF
--- a/examples/custom-types/uniffi.toml
+++ b/examples/custom-types/uniffi.toml
@@ -55,3 +55,20 @@ imports = ["urllib.parse"]
 # Functions to convert between strings and the ParsedUrl class
 into_custom = "urllib.parse.urlparse({})"
 from_custom = "urllib.parse.urlunparse({})"
+
+[bindings.csharp.custom_types.Url]
+imports = ["System"]
+type_name = "Uri"
+into_custom = "new Uri({})"
+from_custom = "{}.AbsoluteUri"
+
+[bindings.go.custom_types.Url]
+imports = ["net/url"]
+type_name = "url.URL"
+into_custom = """u, err := url.Parse({})
+    if err != nil {
+        panic(err)
+    }
+    return *u
+"""
+from_custom = "{}.String()"


### PR DESCRIPTION
When using library mode in tests, its currently not possible to override upstream test crate configurations. This causes problem for `custom_types`, because the crate should also include configuration for C# and Go bindings.

https://github.com/mozilla/uniffi-rs/pull/1788 could help avoid making this change, but its not clear if it will be accepted.