### PR TITLE
Emit Android min SDK 24 compatible code for Timestamp and Duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ scheme, and will be removed in the future. The legacy tags have a corresponding 
 
 ----
 
+### v0.3.3+v0.25.0
+
+- **IMPORTANT**: Kotlin: for out of range Duration/Timestamp values passed into generated bindings,
+    throw `IllegalArgumentException` instead of `java.time.DateTimeException`. This brings down the
+    Android min SDK requirement from 26 to 24.
+
 ### v0.3.2+v0.25.0
 
 - Fix callbacks lifetimes [#17](https://github.com/NordSecurity/uniffi-rs/pull/17)

--- a/docs/release-process-nordsec.md
+++ b/docs/release-process-nordsec.md
@@ -16,7 +16,7 @@ cargo install cargo-release
     git checkout -b bump-X.Y.Z+vA.B.C
     ```
 
-- Update changelog in [README.md](../README.md) to include the changes that were made since last
+- Update changelog in [CHANGELOG.md](../CHANGELOG.md) to include the changes that were made since last
     version. Commit the changelog with message `Update CHANGELOG.md`.
 
 - Update version numbers in `Cargo.toml` files, creates a commit.

--- a/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
@@ -5,10 +5,10 @@ public object FfiConverterDuration: FfiConverterRustBuffer<java.time.Duration> {
         // Type mismatch (should be u32) but we check for overflow/underflow below
         val nanoseconds = buf.getInt().toLong()
         if (seconds < 0) {
-            throw java.time.DateTimeException("Duration exceeds minimum or maximum value supported by uniffi")
+            throw IllegalArgumentException("Duration exceeds minimum or maximum value supported by uniffi")
         }
         if (nanoseconds < 0) {
-            throw java.time.DateTimeException("Duration nanoseconds exceed minimum or maximum supported by uniffi")
+            throw IllegalArgumentException("Duration nanoseconds exceed minimum or maximum supported by uniffi")
         }
         return java.time.Duration.ofSeconds(seconds, nanoseconds)
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
@@ -4,7 +4,7 @@ public object FfiConverterTimestamp: FfiConverterRustBuffer<java.time.Instant> {
         // Type mismatch (should be u32) but we check for overflow/underflow below
         val nanoseconds = buf.getInt().toLong()
         if (nanoseconds < 0) {
-            throw java.time.DateTimeException("Instant nanoseconds exceed minimum or maximum supported by uniffi")
+            throw IllegalArgumentException("Instant nanoseconds exceed minimum or maximum supported by uniffi")
         }
         if (seconds >= 0) {
             return java.time.Instant.EPOCH.plus(java.time.Duration.ofSeconds(seconds, nanoseconds))


### PR DESCRIPTION
DateTimeException requires min SDK 26, but our applications require min SDK 24.