### PR TITLE
Fix callback lifetimes for Kotlin and Python

### DIFF
--- a/fixtures/callbacks/tests/bindings/test_callbacks.kts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.kts
@@ -141,3 +141,11 @@ listOf(1, 2).forEach { v ->
     assert(expected == observed) { "callback is sent on construction: $expected != $observed" }
 }
 rustStringifier.destroy()
+
+// `stringifier` must remain valid after `rustStringifier2` drops the reference
+val stringifier = StoredKotlinStringifier()
+val rustStringifier1 = RustStringifier(stringifier)
+val rustStringifier2 = RustStringifier(stringifier)
+assert("kotlin: 123" == rustStringifier2.fromSimpleType(123))
+rustStringifier2.destroy()
+assert("kotlin: 123" == rustStringifier1.fromSimpleType(123))

--- a/fixtures/callbacks/tests/bindings/test_callbacks.py
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.py
@@ -130,4 +130,14 @@ class TestCallbackErrors(unittest.TestCase):
             rust_getters.get_option(callback, "unexpected-error", True)
         self.assertEqual(cm.exception.reason, repr(ValueError("unexpected value")))
 
+class TestCallbackLifetime(unittest.TestCase):
+    def test_callback_reference_does_not_invalidate_other_references(self):
+        # `stringifier` must remain valid after `rust_stringifier_2` drops the reference
+        stringifier = StoredPythonStringifier()
+        rust_stringifier_1 = RustStringifier(stringifier)
+        rust_stringifier_2 = RustStringifier(stringifier)
+        assert("python: 123" == rust_stringifier_2.from_simple_type(123))
+        del rust_stringifier_2
+        assert("python: 123" == rust_stringifier_1.from_simple_type(123))
+
 unittest.main()

--- a/fixtures/callbacks/tests/bindings/test_callbacks.swift
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.swift
@@ -103,6 +103,16 @@ do {
         assert(expected == observed, "callback is sent on construction: \(expected) != \(observed)")
     }
 
+    do {
+        // `stringifier` must remain valid after `rustStringifier2` drops the reference
+        let stringifier = StoredSwiftStringifier()
+        let rustStringifier1 = RustStringifier(callback: stringifier)
+        do {
+            let rustStringifier2 = RustStringifier(callback: stringifier)
+            assert("swift: 123" == rustStringifier2.fromSimpleType(value: 123))
+        }
+        assert("swift: 123" == rustStringifier1.fromSimpleType(value: 123))
+    }
 
     // 3. Error handling
     do {

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
@@ -7,8 +7,7 @@ class ConcurrentHandleMap:
 
     def __init__(self):
         # type Handle = int
-        self._left_map = {}  # type: Dict[Handle, Any]
-        self._right_map = {}  # type: Dict[Any, Handle]
+        self.handles = {}  # type: Dict[Handle, Any]
 
         self._lock = threading.Lock()
         self._current_handle = 0
@@ -17,25 +16,19 @@ class ConcurrentHandleMap:
 
     def insert(self, obj):
         with self._lock:
-            if obj in self._right_map:
-                return self._right_map[obj]
-            else:
-                handle = self._current_handle
-                self._current_handle += self._stride
-                self._left_map[handle] = obj
-                self._right_map[obj] = handle
-                return handle
+            handle = self._current_handle
+            self._current_handle += self._stride
+            self.handles[handle] = obj
+            return handle
 
     def get(self, handle):
         with self._lock:
-            return self._left_map.get(handle)
+            return self.handles.get(handle)
 
     def remove(self, handle):
         with self._lock:
-            if handle in self._left_map:
-                obj = self._left_map.pop(handle)
-                del self._right_map[obj]
-                return obj
+            if handle in self.handles:
+                return self.handles.pop(handle)
 
 # Magic number for the Rust proxy to call using the same mechanism as every other method,
 # to free the callback once it's dropped by Rust.


### PR DESCRIPTION
Equivalent of https://github.com/NordSecurity/uniffi-bindgen-cs/issues/79

Each time callback is lowered, it should receive a unique handle that will be invalidated when callback reference is dropped by Rust. So, handles should not be re-used for the same callback object.